### PR TITLE
Optionally expose indexes for interleaved elements

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
+++ b/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
@@ -38,6 +38,10 @@ struct KeyedStorage<Key: Hashable & Comparable, Value> {
     subscript(key: Key) -> [Value] {
         return keyMap[key]?.map { buffer[$0].1 } ?? []
     }
+    
+    func indexedValues(for key: Key) -> [(index: Int, value: Value)] {
+        return keyMap[key]?.map { ($0, buffer[$0].1) } ?? []
+    }
 
     mutating func append(_ value: Value, at key: Key) {
         let i = buffer.count

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -241,9 +241,11 @@ extension XMLKeyedDecodingContainer {
 
         let elements = container
             .withShared { keyedBox -> [KeyedBox.Element] in
+                let localKey = key
                 print("DECODING INDEXED??\(type is XMLPositionIndexedSequenceProtocol) \(type) at \(key)")
+                
                 if type is XMLPositionIndexedSequenceProtocol {
-                    print("DECODING INDEXED \(type) at \(key)")
+                    print("DECODING INDEXED \(type) at \(localKey)")
                     return keyedBox.elements
                         .indexedValues(for: key.stringValue)
                         .map { indexedValue -> Box in
@@ -256,7 +258,7 @@ extension XMLKeyedDecodingContainer {
                             )
                         }
                 } else {
-                    print("DECODING REGULAR \(type) at \(key)")
+                    print("DECODING REGULAR \(type) at \(localKey)")
                     return keyedBox.elements[key.stringValue].map {
                         if let singleKeyed = $0 as? SingleKeyedBox {
                             return singleKeyed.element.isNull ? singleKeyed : singleKeyed.element

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -244,7 +244,7 @@ extension XMLKeyedDecodingContainer {
                 let localKey = key
                 print("DECODING INDEXED??\(type is XMLPositionIndexedSequenceProtocol.Type) \(type) at \(key)")
                 
-                if type is XMLPositionIndexedSequenceProtocol {
+                if type is XMLPositionIndexedSequenceProtocol.Type {
                     print("DECODING INDEXED \(type) at \(localKey)")
                     return keyedBox.elements
                         .indexedValues(for: key.stringValue)

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -241,6 +241,7 @@ extension XMLKeyedDecodingContainer {
 
         let elements = container
             .withShared { keyedBox -> [KeyedBox.Element] in
+                print("DECODING INDEXED??\(type is XMLPositionIndexedSequenceProtocol) \(type) at \(key)")
                 if type is XMLPositionIndexedSequenceProtocol {
                     print("DECODING INDEXED \(type) at \(key)")
                     return keyedBox.elements

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -242,6 +242,7 @@ extension XMLKeyedDecodingContainer {
         let elements = container
             .withShared { keyedBox -> [KeyedBox.Element] in
                 if type is XMLPositionIndexedProtocol {
+                    print("DECODING INDEXED \(key)")
                     return keyedBox.elements
                         .indexedValues(for: key.stringValue)
                         .map { indexedValue -> Box in
@@ -254,6 +255,7 @@ extension XMLKeyedDecodingContainer {
                             )
                         }
                 } else {
+                    print("DECODING REGULAR \(key)")
                     return keyedBox.elements[key.stringValue].map {
                         if let singleKeyed = $0 as? SingleKeyedBox {
                             return singleKeyed.element.isNull ? singleKeyed : singleKeyed.element

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -241,7 +241,7 @@ extension XMLKeyedDecodingContainer {
 
         let elements = container
             .withShared { keyedBox -> [KeyedBox.Element] in
-                if type is XMLPositionIndexedProtocol {
+                if type is XMLPositionIndexedSequenceProtocol {
                     print("DECODING INDEXED \(type) at \(key)")
                     return keyedBox.elements
                         .indexedValues(for: key.stringValue)

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -240,12 +240,8 @@ extension XMLKeyedDecodingContainer {
         }
 
         let elements = container
-            .withShared { keyedBox -> [KeyedBox.Element] in
-                let localKey = key
-                print("DECODING INDEXED??\(type is XMLPositionIndexedSequenceProtocol.Type) \(type) at \(key)")
-                
+            .withShared { keyedBox -> [KeyedBox.Element] in                
                 if type is XMLPositionIndexedSequenceProtocol.Type {
-                    print("DECODING INDEXED \(type) at \(localKey)")
                     return keyedBox.elements
                         .indexedValues(for: key.stringValue)
                         .map { indexedValue -> Box in
@@ -258,7 +254,6 @@ extension XMLKeyedDecodingContainer {
                             )
                         }
                 } else {
-                    print("DECODING REGULAR \(type) at \(localKey)")
                     return keyedBox.elements[key.stringValue].map {
                         if let singleKeyed = $0 as? SingleKeyedBox {
                             return singleKeyed.element.isNull ? singleKeyed : singleKeyed.element

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -242,7 +242,7 @@ extension XMLKeyedDecodingContainer {
         let elements = container
             .withShared { keyedBox -> [KeyedBox.Element] in
                 let localKey = key
-                print("DECODING INDEXED??\(type is XMLPositionIndexedSequenceProtocol) \(type) at \(key)")
+                print("DECODING INDEXED??\(type is XMLPositionIndexedSequenceProtocol.Type) \(type) at \(key)")
                 
                 if type is XMLPositionIndexedSequenceProtocol {
                     print("DECODING INDEXED \(type) at \(localKey)")

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -242,7 +242,7 @@ extension XMLKeyedDecodingContainer {
         let elements = container
             .withShared { keyedBox -> [KeyedBox.Element] in
                 if type is XMLPositionIndexedProtocol {
-                    print("DECODING INDEXED \(key)")
+                    print("DECODING INDEXED \(type) at \(key)")
                     return keyedBox.elements
                         .indexedValues(for: key.stringValue)
                         .map { indexedValue -> Box in
@@ -255,7 +255,7 @@ extension XMLKeyedDecodingContainer {
                             )
                         }
                 } else {
-                    print("DECODING REGULAR \(key)")
+                    print("DECODING REGULAR \(type) at \(key)")
                     return keyedBox.elements[key.stringValue].map {
                         if let singleKeyed = $0 as? SingleKeyedBox {
                             return singleKeyed.element.isNull ? singleKeyed : singleKeyed.element

--- a/Sources/XMLCoder/XMLPositionIndexed.swift
+++ b/Sources/XMLCoder/XMLPositionIndexed.swift
@@ -1,5 +1,5 @@
-protocol XMLPositionIndexedElementProtocol { }
-protocol XMLPositionIndexedSequenceProtocol { }
+public protocol XMLPositionIndexedElementProtocol { }
+public protocol XMLPositionIndexedSequenceProtocol { }
 
 public struct XMLPositionIndexed<T: Decodable>: Decodable, XMLPositionIndexedElementProtocol {
     public let index: Int

--- a/Sources/XMLCoder/XMLPositionIndexed.swift
+++ b/Sources/XMLCoder/XMLPositionIndexed.swift
@@ -1,0 +1,6 @@
+protocol XMLPositionIndexedProtocol { }
+
+public struct XMLPositionIndexed<T: Decodable>: Decodable, XMLPositionIndexedProtocol {
+    public let index: Int
+    public let value: T
+}

--- a/Sources/XMLCoder/XMLPositionIndexed.swift
+++ b/Sources/XMLCoder/XMLPositionIndexed.swift
@@ -1,6 +1,9 @@
-protocol XMLPositionIndexedProtocol { }
+protocol XMLPositionIndexedElementProtocol { }
+protocol XMLPositionIndexedSequenceProtocol { }
 
-public struct XMLPositionIndexed<T: Decodable>: Decodable, XMLPositionIndexedProtocol {
+public struct XMLPositionIndexed<T: Decodable>: Decodable, XMLPositionIndexedElementProtocol {
     public let index: Int
     public let value: T
 }
+
+extension Array: XMLPositionIndexedSequenceProtocol where Element: XMLPositionIndexedElementProtocol { }

--- a/Sources/XMLCoder/XMLPositionIndexed.swift
+++ b/Sources/XMLCoder/XMLPositionIndexed.swift
@@ -1,9 +1,11 @@
-public protocol XMLPositionIndexedElementProtocol { }
-public protocol XMLPositionIndexedSequenceProtocol { }
-
 public struct XMLPositionIndexed<T: Decodable>: Decodable, XMLPositionIndexedElementProtocol {
     public let index: Int
     public let value: T
 }
+
+// For type erasure
+
+protocol XMLPositionIndexedElementProtocol { }
+protocol XMLPositionIndexedSequenceProtocol { }
 
 extension Array: XMLPositionIndexedSequenceProtocol where Element: XMLPositionIndexedElementProtocol { }


### PR DESCRIPTION
This PR adds a new public type, `XMLPositionIndexed`. This type can be used within a decoding tree to retain the indexing information of the private type `KeyedStorage`.

## Why is this necessary?

This library already provides a way to retrieve the text value of an XML element, by specifying a coding key of an empty string. 

However, in many XML documents, sub-nodes are nested at meaningful positions within the text value. For example, ARM's machine-readable XML documentation contains the following node:

```xml
<pstext>
    constant bits(16) <anchor>ASID_NONE</anchor> = <a>Zeros</a>();
</pstext>
```

In the current version of this library, this node's elements can be parsed into 3 arrays:
- the `anchor` sub-nodes in order, 
- the `a` sub-nodes in order, 
- the value text segments in order

**However, the relative positioning of these elements to each other is irretrievably lost.**

With the new `XMLPositionIndexed` type, this relative positioning information is retained. Our `Decodable` model for the `pstext` node above can now look like this:

```swift
struct Text: Decodable {

    let valueSegments: [XMLPositionIndexed<String>]
    let links: [XMLPositionIndexed<Link>]
    let anchors: [XMLPositionIndexed<Link>]

    enum CodingKeys: String, CodingKey {
        case valueSegments = ""
        case links = "a"
        case anchors = "anchor"
    }

    struct Link: Decodable {
        let value: String

        enum CodingKeys: String, CodingKey {
            case value = ""
        }
    }
}
```

Each `XMLPositionIndexed` object contains the original value as well as an integer index that can be used in post-processing. As an example, we can easily merge all 3 arrays back together:

```swift
let mergedSegments = (
    text.valueSegments.map { ($0.index, $0.value) }
        + text.links.map { ($0.index, $0.value.value) }
        + text.anchors.map { ($0.index, $0.value.value) }
).sortedByKey { $0.0 }.map { $0.1 }

// mergedSegments = "constant bits(16) ASID_NONE = Zeros();"
```