### PR TITLE
Update XMLCoderElement.swift

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -278,12 +278,12 @@ struct XMLCoderElement: Equatable {
         }
         var string = prefix
 
-        if !key.isEmpty {
-            string += "<\(key)"
-            formatXMLAttributes(formatting, &string, escapedCharacters.attributes)
-        }
-
         if !elements.isEmpty {
+            if !key.isEmpty {
+                string += "<\(key)"
+                formatXMLAttributes(formatting, &string, escapedCharacters.attributes)
+            }
+            
             let prettyPrintElements = prettyPrinted && !containsTextNodes
             if !key.isEmpty {
                 string += prettyPrintElements ? ">\n" : ">"
@@ -293,10 +293,6 @@ struct XMLCoderElement: Equatable {
             if prettyPrintElements { string += prefix }
             if !key.isEmpty {
                 string += "</\(key)>"
-            }
-        } else {
-            if !key.isEmpty {
-                string += " />"
             }
         }
 


### PR DESCRIPTION
The existing implementation was wrong, when the element is empty we set an empty xml tag. We should simply not set it. 

Example :
`
structure Test { var Title: String, var description: String? }
`

In this case calling encode() function like this : 
`
    let xmlEncoder = XMLEncoder()
    xmlEncoder.keyEncodingStrategy = XMLEncoder.KeyEncodingStrategy.capitalized
    let data = try xmlEncoder.encode(self, withRootKey:"Test")
`

Result in : 
`
<Test><Title>"Test"</Title><Description /></Test>
`

The update I made will simply return this instead of an xml string containing an empty element : 
`
<Test><Title>"Test"</Title></Test>
`