### PR TITLE
Fix iOS 11 support warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,15 @@
 
 import PackageDescription
 
+#if swift(>=5.7)
+let platforms: [PackageDescription.SupportedPlatform] = [.macOS(.v10_13), .iOS(.v11), .watchOS(.v4), .tvOS(.v11)]
+#elseif swift(>=5.0)
+let platforms: [PackageDescription.SupportedPlatform]? = nil
+#endif
+
 let package = Package(
     name: "XMLCoder",
+    platforms: platforms,
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Hi,
I would like to contribute fixing a recent warning.

The new Xcode 14 uses next SDKs as base: iOS 11.0, macOS 10.13, watchOS 4.0 and tvOS 11.0. Compiling in this Xcode shows a warning.
Handle this restrictions relying on swift version (which is also vinculated to each Xcode version).

Regards and comments welcomed