### PR TITLE
Test with Xcode 14.0 and Swift 5.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
             iOS: "15.5"
             tvOS: "15.4"
             useCodecov: "false"
-          - xcode: "14.0" # Swift 5.6
+          - xcode: "14.0" # Swift 5.7
             macOS: "12"
             iOS: "16.0"
             tvOS: "16.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,11 @@ jobs:
             macOS: "12"
             iOS: "15.5"
             tvOS: "15.4"
+            useCodecov: "false"
+          - xcode: "14.0" # Swift 5.6
+            macOS: "12"
+            iOS: "16.0"
+            tvOS: "16.0"
             useCodecov: "true"
 
     runs-on: macos-${{ matrix.macOS }}

--- a/Tests/XMLCoderTests/AdvancedFeatures/ErrorContextTest.swift
+++ b/Tests/XMLCoderTests/AdvancedFeatures/ErrorContextTest.swift
@@ -31,26 +31,34 @@ final class ErrorContextTest: XCTestCase {
                 return
             }
 
-            #if os(Linux) && swift(<5.4)
-            // XML Parser returns a different column on Linux
-            // https://bugs.swift.org/browse/SR-11192
-            XCTAssertEqual(ctx.debugDescription, """
-            \(underlying.localizedDescription) \
-            at line 1, column 7:
-            `ah //>`
-            """)
-            #elseif os(Windows) || os(Linux)
-            XCTAssertEqual(ctx.debugDescription, """
-            \(underlying.localizedDescription) \
-            at line 1, column 10:
-            `//>`
-            """)
-            #else
-            XCTAssertEqual(ctx.debugDescription, """
+            let column2 = """
             \(underlying.localizedDescription) \
             at line 1, column 2:
             `<blah `
-            """)
+            """
+            let column7 = """
+            \(underlying.localizedDescription) \
+            at line 1, column 7:
+            `ah //>`
+            """
+            let column10 = """
+            \(underlying.localizedDescription) \
+            at line 1, column 10:
+            `//>`
+            """
+
+            #if (os(Linux) && swift(<5.4)) || os(iOS)
+            // XML Parser returns a different column on Linux and iOS 16+
+            // https://bugs.swift.org/browse/SR-11192
+            XCTAssertEqual(ctx.debugDescription, column7)
+            #elseif os(Windows) || os(Linux)
+            XCTAssertEqual(ctx.debugDescription, column10)
+            #else
+            if #available(iOS 16.0, tvOS 16.0, *) {
+                XCTAssertEqual(ctx.debugDescription, column7)
+            } else {
+                XCTAssertEqual(ctx.debugDescription, column2)
+            }
             #endif
         }
     }
@@ -81,22 +89,30 @@ final class ErrorContextTest: XCTestCase {
                 return
             }
 
-            #if os(Linux)
-            // XML Parser returns a different column on Linux
-            // https://bugs.swift.org/browse/SR-11192
-            XCTAssertEqual(ctx.debugDescription, """
+            let line4column1 = """
             \(underlying.localizedDescription) \
             at line 4, column 1:
             `blah>
             <c`
-            """)
-            #else
-            XCTAssertEqual(ctx.debugDescription, """
+            """
+
+            let line3column8 = """
             \(underlying.localizedDescription) \
             at line 3, column 8:
             `blah>
             <c`
-            """)
+            """
+
+            #if os(Linux)
+            // XML Parser returns a different column on Linux
+            // https://bugs.swift.org/browse/SR-11192
+            XCTAssertEqual(ctx.debugDescription, line4column1)
+            #else
+            if #available(iOS 16.0, tvOS 16.0, *) {
+                XCTAssertEqual(ctx.debugDescription, line4column1)
+            } else {
+                XCTAssertEqual(ctx.debugDescription, line3column8)
+            }
             #endif
         }
     }

--- a/Tests/XMLCoderTests/AdvancedFeatures/ErrorContextTest.swift
+++ b/Tests/XMLCoderTests/AdvancedFeatures/ErrorContextTest.swift
@@ -54,7 +54,7 @@ final class ErrorContextTest: XCTestCase {
             #elseif os(Windows) || os(Linux)
             XCTAssertEqual(ctx.debugDescription, column10)
             #else
-            if #available(iOS 16.0, tvOS 16.0, *) {
+            if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
                 XCTAssertEqual(ctx.debugDescription, column7)
             } else {
                 XCTAssertEqual(ctx.debugDescription, column2)
@@ -108,7 +108,7 @@ final class ErrorContextTest: XCTestCase {
             // https://bugs.swift.org/browse/SR-11192
             XCTAssertEqual(ctx.debugDescription, line4column1)
             #else
-            if #available(iOS 16.0, tvOS 16.0, *) {
+            if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
                 XCTAssertEqual(ctx.debugDescription, line4column1)
             } else {
                 XCTAssertEqual(ctx.debugDescription, line3column8)

--- a/Tests/XMLCoderTests/AdvancedFeatures/ErrorContextTest.swift
+++ b/Tests/XMLCoderTests/AdvancedFeatures/ErrorContextTest.swift
@@ -47,7 +47,7 @@ final class ErrorContextTest: XCTestCase {
             `//>`
             """
 
-            #if (os(Linux) && swift(<5.4)) || os(iOS)
+            #if os(Linux) && swift(<5.4)
             // XML Parser returns a different column on Linux and iOS 16+
             // https://bugs.swift.org/browse/SR-11192
             XCTAssertEqual(ctx.debugDescription, column7)

--- a/test_xcodebuild.sh
+++ b/test_xcodebuild.sh
@@ -11,7 +11,7 @@ xcodebuild test -scheme XMLCoder \
 xcodebuild test -scheme XMLCoder \
   -sdk appletvsimulator -destination "$TVOS_DEVICE" | xcpretty
 
-if [ "$CODECOV_JOB" = "true"] ; then
+if [ "$CODECOV_JOB" = "true" ] ; then
   xcodebuild test -enableCodeCoverage YES -scheme XMLCoder \
     -sdk macosx | xcpretty
   bash <(curl -s https://codecov.io/bash)

--- a/test_xcodebuild.sh
+++ b/test_xcodebuild.sh
@@ -8,8 +8,11 @@ sudo xcode-select --switch /Applications/$1.app/Contents/Developer
 xcodebuild -version
 xcodebuild test -scheme XMLCoder \
   -sdk iphonesimulator -destination "$IOS_DEVICE" | xcpretty
-xcodebuild test -scheme XMLCoder \
-  -sdk appletvsimulator -destination "$TVOS_DEVICE" | xcpretty
+
+if $(xcodebuild -showdestinations -scheme XMLCoder | grep 'platform:tvOS.* OS:'); then
+  xcodebuild test -scheme XMLCoder \
+    -sdk appletvsimulator -destination "$TVOS_DEVICE" | xcpretty
+fi
 
 if [ "$CODECOV_JOB" = "true" ] ; then
   xcodebuild test -enableCodeCoverage YES -scheme XMLCoder \


### PR DESCRIPTION
The way the XML parser from Foundation treats errors differs between SDK versions, we have to handle this in our tests accordingly.