### PR TITLE
Adds `.noEmptyElements` option to OutputFormatting

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -291,12 +291,14 @@ struct XMLCoderElement: Equatable {
             formatXMLAttributes(formatting, &string, escapedCharacters.attributes)
         }
 
-        if !elements.isEmpty {
+        if !elements.isEmpty || formatting.contains(.noEmptyElements) {
             let prettyPrintElements = prettyPrinted && !containsTextNodes
             if !key.isEmpty {
                 string += prettyPrintElements ? ">\n" : ">"
             }
-            formatXMLElements(escapedCharacters, formatting, indentation, &string, level, prettyPrintElements)
+            if !elements.isEmpty {
+                formatXMLElements(escapedCharacters, formatting, indentation, &string, level, prettyPrintElements)
+            }
 
             if prettyPrintElements { string += prefix }
             if !key.isEmpty {

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -27,6 +27,9 @@ open class XMLEncoder {
 
         /// Produce XML with keys sorted in lexicographic order.
         public static let sortedKeys = OutputFormatting(rawValue: 1 << 1)
+
+        /// Produce XML with no short-hand annotation for empty elements, e.g., use `<p></p>` over `</p>`
+        public static let noEmptyElements = OutputFormatting(rawValue: 1 << 2)
     }
 
     /// The indentation to use when XML is pretty-printed.

--- a/Tests/XMLCoderTests/NodeEncodingStrategyTests.swift
+++ b/Tests/XMLCoderTests/NodeEncodingStrategyTests.swift
@@ -313,11 +313,7 @@ final class NodeEncodingStrategyTests: XCTestCase {
 
     func testNoEmptyElements() {
         let encoder = XMLEncoder()
-        if #available(macOS 10.13, *) {
-            encoder.outputFormatting = [.noEmptyElements]
-        } else {
-            return
-        }
+        encoder.outputFormatting = [.noEmptyElements]
 
         do {
             let data = try encoder.encode(UnkeyedContainer(elements: []), withRootKey: "container")

--- a/Tests/XMLCoderTests/NodeEncodingStrategyTests.swift
+++ b/Tests/XMLCoderTests/NodeEncodingStrategyTests.swift
@@ -309,4 +309,27 @@ final class NodeEncodingStrategyTests: XCTestCase {
             XCTAssert(false, "failed to decode the example: \(error)")
         }
     }
+    
+
+    func testNoEmptyElements() {
+        let encoder = XMLEncoder()
+        if #available(macOS 10.13, *) {
+            encoder.outputFormatting = [.noEmptyElements]
+        } else {
+            return
+        }
+
+        do {
+            let data = try encoder.encode(UnkeyedContainer(elements: []), withRootKey: "container")
+            let xml = String(data: data, encoding: .utf8)!
+
+            let expected =
+                """
+                <container></container>
+                """
+            XCTAssertEqual(xml, expected)
+        } catch {
+            XCTAssert(false, "failed to decode the example: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
Opts out of empty element shorthand.

---

I'm using XMLCoder to generate XML from my Swift data models for use in another system that doesn't handle the empty-elements, so I've added this option to allow generating XML that it can ingest. Not sure if `OutputFormatting` is the right place for this.