### PR TITLE
Optimise parsing by removing excessive copying.

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
+++ b/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
@@ -75,23 +75,3 @@ extension KeyedStorage: CustomStringConvertible {
         return "[\(result)]"
     }
 }
-
-extension KeyedStorage where Key == String, Value == Box {
-    func merge(element: XMLCoderElement) -> KeyedStorage<String, Box> {
-        var result = self
-
-        let hasElements = !element.elements.isEmpty
-        let hasAttributes = !element.attributes.isEmpty
-        let hasText = element.stringValue != nil
-
-        if hasElements || hasAttributes {
-            result.append(element.transformToBoxTree(), at: element.key)
-        } else if hasText {
-            result.append(element.transformToBoxTree(), at: element.key)
-        } else {
-            result.append(SingleKeyedBox(key: element.key, element: NullBox()), at: element.key)
-        }
-
-        return result
-    }
-}

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -115,9 +115,25 @@ struct XMLCoderElement: Equatable {
         let attributes = KeyedStorage(self.attributes.map { attribute in
             (key: attribute.key, value: StringBox(attribute.value) as SimpleBox)
         })
-        let storage = KeyedStorage<String, Box>()
-        let elements = self.elements.reduce(storage) { $0.merge(element: $1) }
-        return KeyedBox(elements: elements, attributes: attributes)
+
+        var storage = KeyedStorage<String, Box>()
+
+        for element in self.elements {
+
+            let hasElements = !element.elements.isEmpty
+            let hasAttributes = !element.attributes.isEmpty
+            let hasText = element.stringValue != nil
+            
+            if hasElements || hasAttributes {
+                storage.append(element.transformToBoxTree(), at: element.key)
+            } else if hasText {
+                storage.append(element.transformToBoxTree(), at: element.key)
+            } else {
+                storage.append(SingleKeyedBox(key: element.key, element: NullBox()), at: element.key)
+            }
+        }
+
+        return KeyedBox(elements: storage, attributes: attributes)
     }
 
     func toXMLString(


### PR DESCRIPTION
In the current implementation the copy-on-write causes excessive copying when building the box tree.

I've inlined the `merge` function into `transformToBoxTree` and used a `storage` variable to avoid it being passed around and copied.

In my tests this results in a ~30x speedup and makes all the difference in my use case.

Also IMO the code is a little clearer now as it shows the recursive nature of the algorithm in one function.
